### PR TITLE
feat: add support for `application/*` in `rewrite.rebase`

### DIFF
--- a/src/extensions/decode-body/decode-body.extension.ts
+++ b/src/extensions/decode-body/decode-body.extension.ts
@@ -27,20 +27,19 @@ export class DecodeBodyExtension extends ProxyExtension {
       context.serviceResponseBody = await promisify(gunzip)(
         context.serviceResponseBody,
       );
-      context.serviceResponseHeaders.delete('content-length');
     } else if (headers.get('content-encoding') === 'br') {
       context.serviceResponseHeaders.set('content-encoding', 'identity');
       context.serviceResponseBody = Buffer.from(
         brotli(context.serviceResponseBody),
       );
-      context.serviceResponseHeaders.delete('content-length');
     } else if (headers.get('content-encoding') === 'deflate') {
       context.serviceResponseHeaders.set('content-encoding', 'identity');
       context.serviceResponseBody = await promisify(inflate)(
         context.serviceResponseBody,
       );
-      context.serviceResponseHeaders.delete('content-length');
     }
+
+    context.serviceResponseHeaders.delete('content-length');
 
     return context;
   };

--- a/src/extensions/rewrite-rebase/processors/abstract.processor.ts
+++ b/src/extensions/rewrite-rebase/processors/abstract.processor.ts
@@ -3,7 +3,7 @@ import { OnModifyServiceResponseWithBody } from 'src/context.types';
 import { ParsedMediaType } from 'content-type';
 import { ProxyFrameworkApp } from 'src/proxy-framework.app';
 
-export abstract class AbstractResponseProcessor extends ProxyExtension {
+export abstract class AbstractProcessor extends ProxyExtension {
   abstract process(
     context: OnModifyServiceResponseWithBody,
     contentType: ParsedMediaType,

--- a/src/extensions/rewrite-rebase/processors/css.processor.ts
+++ b/src/extensions/rewrite-rebase/processors/css.processor.ts
@@ -1,8 +1,8 @@
 import { OnModifyServiceResponseWithBody } from 'src/context.types';
 import { ParsedMediaType } from 'content-type';
-import { AbstractResponseProcessor } from 'src/extensions/rewrite-rebase/processors/abstract-response.processor';
+import { AbstractProcessor } from 'src/extensions/rewrite-rebase/processors/abstract.processor';
 
-export class CSSResponseProcessor extends AbstractResponseProcessor {
+export class CSSProcessor extends AbstractProcessor {
   process(
     context: OnModifyServiceResponseWithBody,
     contentType: ParsedMediaType,

--- a/src/extensions/rewrite-rebase/processors/html.processor.ts
+++ b/src/extensions/rewrite-rebase/processors/html.processor.ts
@@ -1,8 +1,8 @@
 import { OnModifyServiceResponseWithBody } from 'src/context.types';
 import { ParsedMediaType } from 'content-type';
-import { AbstractResponseProcessor } from 'src/extensions/rewrite-rebase/processors/abstract-response.processor';
+import { AbstractProcessor } from 'src/extensions/rewrite-rebase/processors/abstract.processor';
 
-export class HTMLResponseProcessor extends AbstractResponseProcessor {
+export class HTMLProcessor extends AbstractProcessor {
   process(
     context: OnModifyServiceResponseWithBody,
     contentType: ParsedMediaType,

--- a/src/extensions/rewrite-rebase/processors/text.processor.ts
+++ b/src/extensions/rewrite-rebase/processors/text.processor.ts
@@ -1,8 +1,8 @@
 import { OnModifyServiceResponseWithBody } from 'src/context.types';
 import { ParsedMediaType } from 'content-type';
-import { AbstractResponseProcessor } from 'src/extensions/rewrite-rebase/processors/abstract-response.processor';
+import { AbstractProcessor } from 'src/extensions/rewrite-rebase/processors/abstract.processor';
 
-export class TextResponseProcessor extends AbstractResponseProcessor {
+export class TextProcessor extends AbstractProcessor {
   process(
     context: OnModifyServiceResponseWithBody,
     contentType: ParsedMediaType,

--- a/src/extensions/rewrite-rebase/rewrite-rebase.extension.ts
+++ b/src/extensions/rewrite-rebase/rewrite-rebase.extension.ts
@@ -5,22 +5,19 @@ import {
   OnModifyServiceResponseWithBody,
 } from 'src/context.types';
 import { parse, ParsedMediaType } from 'content-type';
-import { AbstractResponseProcessor } from 'src/extensions/rewrite-rebase/processors/abstract-response.processor';
-import { HTMLResponseProcessor } from 'src/extensions/rewrite-rebase/processors/html-response.processor';
-import { TextResponseProcessor } from 'src/extensions/rewrite-rebase/processors/text-response.processor';
-import { CSSResponseProcessor } from 'src/extensions/rewrite-rebase/processors/css-response.processor';
+import { AbstractProcessor } from 'src/extensions/rewrite-rebase/processors/abstract.processor';
+import { HTMLProcessor } from 'src/extensions/rewrite-rebase/processors/html.processor';
+import { TextProcessor } from 'src/extensions/rewrite-rebase/processors/text.processor';
+import { CSSProcessor } from 'src/extensions/rewrite-rebase/processors/css.processor';
 
 export class RewriteRebaseExtension extends ProxyExtension {
   static dependencies = [
     DecodeBodyExtension,
-    HTMLResponseProcessor,
-    TextResponseProcessor,
-    CSSResponseProcessor,
+    HTMLProcessor,
+    TextProcessor,
+    CSSProcessor,
   ];
-  private contentTypeToProcessorMap = new Map<
-    string,
-    AbstractResponseProcessor
-  >();
+  private contentTypeToProcessorMap = new Map<string, AbstractProcessor>();
 
   async init(): Promise<void> {
     this.app.onStart
@@ -35,17 +32,16 @@ export class RewriteRebaseExtension extends ProxyExtension {
 
     this.contentTypeToProcessorMap.set(
       'text/html',
-      this.app.get(HTMLResponseProcessor),
+      this.app.get(HTMLProcessor),
     );
 
-    this.contentTypeToProcessorMap.set(
-      'text/css',
-      this.app.get(CSSResponseProcessor),
-    );
+    this.contentTypeToProcessorMap.set('text/css', this.app.get(CSSProcessor));
+
+    this.contentTypeToProcessorMap.set('text/*', this.app.get(TextProcessor));
 
     this.contentTypeToProcessorMap.set(
-      'text/*',
-      this.app.get(TextResponseProcessor),
+      'application/*',
+      this.app.get(TextProcessor),
     );
   }
 


### PR DESCRIPTION
`rewrite.rebase` is currently supported only for `text/*`. This PR adds support for `application/json` and `application/xml` (should work for `application/*` in general).

`application/*` is simply handled with `TextResponseProcessor`. I suggest removing `Response` from `Processor` names, as `TextProcessor` seems more generic. `application/*` can be treated as text, but is not a **TextResponse** strictly speaking (if we consider text response to have `text/*` content type).

PR fixes an issue with `Content-Length`. We have been passing down the header if response from the origin server was not compressed. It will not work when we are modifying the response. We have two options: remove the origin content-header after reading body in all cases or remove it on demand by extension that modifies the response. I chose the first option. I think that there is no need to keep the header, we can always calculate it on returning the response.